### PR TITLE
Update of masses in the database

### DIFF
--- a/KFParticle/KFParticleDatabase.cxx
+++ b/KFParticle/KFParticleDatabase.cxx
@@ -46,8 +46,8 @@ KFParticleDatabase::KFParticleDatabase():
   fMass[1] = 0.105658;
   fMass[2] = 0.13957;
   fMass[3] = 0.493667;
-  fMass[4] = 0.9382723;
-  fMass[5] = 1.876124;
+  fMass[4] = 0.9382721;
+  fMass[5] = 1.875613;
   fMass[6] = 2.809432;
   fMass[7] = 2.809413;
   fMass[8] = 3.728400;

--- a/KFParticle/KFParticleDatabase.cxx
+++ b/KFParticle/KFParticleDatabase.cxx
@@ -45,12 +45,12 @@ KFParticleDatabase::KFParticleDatabase():
   fMass[0] = 0.000510999;
   fMass[1] = 0.105658;
   fMass[2] = 0.13957;
-  fMass[3] = 0.493667;
+  fMass[3] = 0.493677;
   fMass[4] = 0.9382721;
   fMass[5] = 1.875613;
-  fMass[6] = 2.809432;
-  fMass[7] = 2.809413;
-  fMass[8] = 3.728400;
+  fMass[6] = 2.808921;
+  fMass[7] = 2.8094135;
+  fMass[8] = 3.728401;
   fMass[9] = 1.197449;
   fMass[10] = 1.18937;
   fMass[11] = 1.32171;

--- a/KFParticle/KFParticleDatabase.cxx
+++ b/KFParticle/KFParticleDatabase.cxx
@@ -49,7 +49,7 @@ KFParticleDatabase::KFParticleDatabase():
   fMass[4] = 0.9382721;
   fMass[5] = 1.875613;
   fMass[6] = 2.808921;
-  fMass[7] = 2.8094135;
+  fMass[7] = 2.808391;
   fMass[8] = 3.728401;
   fMass[9] = 1.197449;
   fMass[10] = 1.18937;


### PR DESCRIPTION
I have updated the masses of kaons, protons, deuterons, tritons, helium-3 and helium-4 to the most recent values
(which now also match the masses used in your MC simulations)